### PR TITLE
Update links to open issue to ensure that templates can be used

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -13,9 +13,9 @@ We're always eager to improve, and your input is valuable to us. Thank you for b
 If you're facing any issues specific to a ROS distribution, we recommend creating an issue in the corresponding GitHub repository.
 You can also contribute by following the guidelines in our [contribution](Contributing.md) guide.
 
-* [ROS Noetic](https://github.com/RoboStack/ros-noetic/issues/new)
-* [ROS2 Humble](https://github.com/RoboStack/ros-humble/issues/new)
-* [ROS2 Galactic](https://github.com/RoboStack/ros-galactic/issues/new) (not actively maintained anymore)
-* [ROS2 Foxy](https://github.com/RoboStack/ros-foxy/issues/new) (not actively maintained anymore)
+* [ROS Noetic](https://github.com/RoboStack/ros-noetic/issues/new/choose)
+* [ROS2 Humble](https://github.com/RoboStack/ros-humble/issues/new/choose)
+* [ROS2 Galactic](https://github.com/RoboStack/ros-galactic/issues/new/choose) (not actively maintained anymore)
+* [ROS2 Foxy](https://github.com/RoboStack/ros-foxy/issues/new/choose) (not actively maintained anymore)
 
 By submitting your issue to the appropriate repo, we can better understand and address your concerns. Thank you for helping us improve the RoboStack ecosystem! 


### PR DESCRIPTION
Fix issue reported by @nvander in https://github.com/RoboStack/ros-noetic/issues/390#issuecomment-1703263848 , i.e. fix the link to open new issues to ensure that users are suggested to use templates.