### PR TITLE
GettingStarted: add rosdep to the "Default tools to help with local development of ROS package"

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -74,7 +74,7 @@ conda install mamba -c conda-forge
 === "Mamba"
 
     ```bash title="Default tools to help with local development of ROS packages"
-    mamba install compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools
+    mamba install compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools rosdep
     ```
 
     ```bash title="Additional dependencies for developing on windows"
@@ -91,7 +91,7 @@ conda install mamba -c conda-forge
 === "Micromamba"
 
     ```bash title="Default tools to help with local development of ROS packages"
-    micromamba install -c conda-forge compilers cmake pkg-config make ninja colcon-common-extensions
+    micromamba install -c conda-forge compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools rosdep
     ```
 
     ```bash title="Additional dependencies for developing on windows"


### PR DESCRIPTION
I also added `catkin_tools` that was in the mamba but not in the micromamba section.