### PR TITLE
Add MacOS troubleshooting steps for "RLException: Unable to contact my own server" error

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -23,7 +23,7 @@ First, make sure that the package is installed; in the example case it would be 
 ### Why does autocomplete not work in zsh environments?
 You will need to install https://github.com/conda-incubator/conda-zsh-completion
 
-### How to fix RLException error on MacOS(M Chip & Intel CPUs) ?
+### How to fix RLException error on MacOS (M Chip & Intel CPUs) ?
 If you run into "RLException: Unable to contact my own server" error on MacOS here are the instructions that you need to follow in order to resolve that issue:
 - Set up ROS_MASTER URI at 127.0.0.1 on port 11311 : `export ROS_MASTER_URI=http://127.0.0.1:11311`
 - Set up ROS_HOSTNAME : `export ROS_HOSTNAME=127.0.0.1`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -23,6 +23,14 @@ First, make sure that the package is installed; in the example case it would be 
 ### Why does autocomplete not work in zsh environments?
 You will need to install https://github.com/conda-incubator/conda-zsh-completion
 
+### How to fix RLException error on MacOS(M Chip & Intel CPUs) ?
+If you run into "RLException: Unable to contact my own server" error on MacOS here are the instructions that you need to follow in order to resolve that issue:
+- Set up ROS_MASTER URI at 127.0.0.1 on port 11311 : `export ROS_MASTER_URI=http://127.0.0.1:11311`
+- Set up ROS_HOSTNAME : `export ROS_HOSTNAME=127.0.0.1`
+- Open the hosts file with a text editor like nano: `sudo nano /etc/hosts`
+- Add the following lines if they are not already present: `127.0.0.1   macbookpro` and `127.0.0.1   localhost`
+- Then save the file and restart your terminal.
+
 ### Can I use RoboStack in a non-conda virtual environment?
 RoboStack is based on conda-forge and will not work without conda. However, check out [rospypi](https://github.com/rospypi/simple) which can run in a pure Python virtualenv. rospypi supports tf2 and other binary packages.
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -157,7 +157,7 @@ In the conda environment activation is the ROS activation included. There is no 
     rviz2
     ```
 
-If you run into any issues or for any frequently asked questions, you can check the [FAQ page]([https://link-url-here.org](https://robostack.github.io/FAQ.html))
+If you run into any issues or for any frequently asked questions, you can check the [FAQ page](https://robostack.github.io/FAQ.html)
 
 ## Updating
 Updating all packages in your environment is as easy as:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -157,6 +157,8 @@ In the conda environment activation is the ROS activation included. There is no 
     rviz2
     ```
 
+If you run into any issues or for any frequently asked questions, you can check the [FAQ page]([https://link-url-here.org](https://robostack.github.io/FAQ.html))
+
 ## Updating
 Updating all packages in your environment is as easy as:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -156,8 +156,13 @@ In the conda environment activation is the ROS activation included. There is no 
     micromamba activate ros_env
     rviz2
     ```
-
-
+If you run into "RLException: Unable to contact my own server" error on MacOS here are the instructions that you need to follow in order to resolve that issue:
+- Set up ROS_MASTER URI at 127.0.0.1 on port 11311 : `export ROS_MASTER_URI=http://127.0.0.1:11311`
+- Set up ROS_HOSTNAME : `export ROS_HOSTNAME=127.0.0.1`
+- Open the hosts file with a text editor like nano: `sudo nano /etc/hosts`
+- Add the following lines if they are not already present: `127.0.0.1   macbookpro` and `127.0.0.1   localhost`
+- Then save the file and restart your terminal.
+  
 ## Updating
 Updating all packages in your environment is as easy as:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -156,13 +156,7 @@ In the conda environment activation is the ROS activation included. There is no 
     micromamba activate ros_env
     rviz2
     ```
-If you run into "RLException: Unable to contact my own server" error on MacOS here are the instructions that you need to follow in order to resolve that issue:
-- Set up ROS_MASTER URI at 127.0.0.1 on port 11311 : `export ROS_MASTER_URI=http://127.0.0.1:11311`
-- Set up ROS_HOSTNAME : `export ROS_HOSTNAME=127.0.0.1`
-- Open the hosts file with a text editor like nano: `sudo nano /etc/hosts`
-- Add the following lines if they are not already present: `127.0.0.1   macbookpro` and `127.0.0.1   localhost`
-- Then save the file and restart your terminal.
-  
+
 ## Updating
 Updating all packages in your environment is as easy as:
 


### PR DESCRIPTION
Added detailed instructions to resolve the "RLException: Unable to contact my own server" error on MacOS. Instructions include setting the ROS_MASTER_URI and ROS_HOSTNAME to 127.0.0.1 and configuring the /etc/hosts file.