### PR TITLE
FAQ: colcon argument --cmake-args must be passed without quotes

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -40,7 +40,7 @@ RoboStack is based on conda-forge and will not work without conda. However, chec
 
 It is possible that if you are having problems in finding the Python installed in your environment, and for some reason the Python of your system is found instead. To workaround these kind of problems, a trick is to explicitly specify which Python to use to CMake, via: 
 ~~~
---cmake-args "-DPython_EXECUTABLE=$CONDA_PREFIX/bin/python -DPython3_EXECUTABLE=$CONDA_PREFIX/bin/python -DPYTHON_EXECUTABLE=$CONDA_PREFIX/bin/python -DPython3_FIND_STRATEGY=LOCATION -DPython_FIND_STRATEGY=LOCATION"
+--cmake-args -DPython_EXECUTABLE=$CONDA_PREFIX/bin/python -DPython3_EXECUTABLE=$CONDA_PREFIX/bin/python -DPYTHON_EXECUTABLE=$CONDA_PREFIX/bin/python -DPython3_FIND_STRATEGY=LOCATION -DPython_FIND_STRATEGY=LOCATION
 ~~~
 if you are using colcon or:
 ~~~


### PR DESCRIPTION
I am not sure why we put quotes here, but passing quotes to `--cmake-args` colcon arguments results in all the arguments considered as a single CMake argument by cmake.

To validated this, I prepare a simple pixi example at https://gist.github.com/traversaro/a00500eb18e207da121ab8d7af172896 : 

~~~
traversaro@IITBMP014LW012:~$ git clone https://gist.github.com/traversaro/a00500eb18e207da121ab8d7af172896 colcon-cmake-args-quotes-example
Cloning into 'colcon-cmake-args-quotes-example'...
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (5/5), done.
Receiving objects: 100% (5/5), 12.44 KiB | 12.44 MiB/s, done.
remote: Total 5 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
traversaro@IITBMP014LW012:~$ cd colcon-cmake-args-quotes-example/
traversaro@IITBMP014LW012:~/colcon-cmake-args-quotes-example$ pixi run run_colcon_with_quotes
✨ Pixi task (run_colcon_with_quotes): rm -rf .pixi_colcon_ws && echo Run colcon && mkdir -p .pixi_colcon_ws/src/testprj && cp CMakeLists.txt .pixi_colcon_ws/src/testprj && cd .pixi_colcon_ws && colcon build --event-handlers console_direct+ --cmake-args "-DENABLE_FEATURE_A:BOOL=ON -DENABLE_FEATURE_B:BOOL=ON"
Run colcon
Starting >>> MyCMakeProject
-- ENABLE_FEATURE_A: ON -DENABLE_FEATURE_B:BOOL=ON
-- ENABLE_FEATURE_B: OFF
-- Configuring done
-- Generating done
-- Build files have been written to: /home/traversaro/colcon-cmake-args-quotes-example/.pixi_colcon_ws/build/MyCMakeProject
[0.609s] colcon.colcon_cmake.task.cmake.build WARNING Could not run installation step for package 'MyCMakeProject' because it has no 'install' target
Finished <<< MyCMakeProject [0.06s]

Summary: 1 package finished [0.26s]
traversaro@IITBMP014LW012:~/colcon-cmake-args-quotes-example$ pixi run run_colcon_without_quotes
✨ Pixi task (run_colcon_without_quotes): rm -rf .pixi_colcon_ws && echo Run colcon && mkdir -p .pixi_colcon_ws/src/testprj && cp CMakeLists.txt .pixi_colcon_ws/src/testprj && cd .pixi_colcon_ws && colcon build --event-handlers console_direct+ --cmake-args -DENABLE_FEATURE_A:BOOL=ON -DENABLE_FEATURE_B:BOOL=ON
Run colcon
Starting >>> MyCMakeProject
-- ENABLE_FEATURE_A: ON
-- ENABLE_FEATURE_B: ON
-- Configuring done
-- Generating done
-- Build files have been written to: /home/traversaro/colcon-cmake-args-quotes-example/.pixi_colcon_ws/build/MyCMakeProject
[0.296s] colcon.colcon_cmake.task.cmake.build WARNING Could not run installation step for package 'MyCMakeProject' because it has no 'install' target
Finished <<< MyCMakeProject [0.04s]

Summary: 1 package finished [0.09s]
~~~

You can see that if quotes are used, `--cmake-args "-DENABLE_FEATURE_A:BOOL=ON -DENABLE_FEATURE_B:BOOL=ON"` is intepreted as assigning the value `ON -DENABLE_FEATURE_B:BOOL=ON` to the variable `ENABLE_FEATURE_A`, that is clearly wrong.

I discovered this after debugging some strange failures with @matteomastrogiuseppe .