### PR TITLE
In pixi install instructions only add libgl-devel dependency on Linux

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -182,6 +182,8 @@ You can install Robostack using either Mamba or Pixi. We recommend using Pixi fo
     pkg-config = "*"
     make = "*"
     ninja = "*"
+
+    [target.linux.dependencies]
     libgl-devel = "*"
 
     [environments]


### PR DESCRIPTION
Fix https://github.com/RoboStack/robostack.github.io/issues/78 .