### PR TITLE
Do not install Python 3.11 on mamba

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -30,7 +30,7 @@ You can install Robostack using either Mamba or Pixi. We recommend using Pixi fo
     === "Mamba"
 
         ```bash title="Prepare an environment to use the correct channels"
-        mamba create -n ros_env python=3.11
+        mamba create -n ros_env
         mamba activate ros_env
 
         # this adds the conda-forge channel to the new created environment configuration 


### PR DESCRIPTION
Different robostack rebuilds may have different Python versions, always installing 3.11 is misleading (see https://github.com/RoboStack/ros-jazzy/issues/69).