### PR TITLE
Remove references to Visual Studio 2019

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -119,13 +119,9 @@ You can install Robostack using either Mamba or Pixi. We recommend using Pixi fo
         ```
 
     !!! tip "Developing on Windows"
-        - Windows users also need Visual Studio (2019 or 2022) with C++ support
+        - Windows users also need Visual Studio 2022 with C++ support
         - You can download them here: [https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-160](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-160)
-        
-        If you use Visual Studio 2022, you must also install the command line tool (pre-included included for VS2019):
-        ```
-        mamba install vs2022_win-64
-        ```
+
 
 === "Pixi"
     ## Install Pixi


### PR DESCRIPTION
Since conda-forge switched to vs2022 by default in June 2025 (see https://conda-forge.org/news/2025/06/11/moving-to-vs2022/), we also only support vs2022, and now `cxx-compiler` install by defaults the vs2022_win-64 package (see https://github.com/conda-forge/compilers-feedstock/pull/72), so we can simplify the instructions by only mentioning vs2022.