### PR TITLE
fix: disable font ligatures in code

### DIFF
--- a/src/components/home/QuickStart.astro
+++ b/src/components/home/QuickStart.astro
@@ -59,6 +59,7 @@ const commands = [
     border-radius: var(--radius-md);
     overflow: hidden;
     font-family: var(--font-mono);
+    font-variant-ligatures: none;
   }
   .term-bar {
     display: flex;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -25,6 +25,14 @@
   --sl-font-mono: "JetBrains Mono";
 }
 
+/* JetBrains Mono enables ligatures by default; keep code as plain glyphs. */
+code,
+pre,
+kbd,
+samp {
+  font-variant-ligatures: none;
+}
+
 /* Docs headings share the frontpage's serif display face. */
 .sl-markdown-content :is(h1, h2, h3, h4, h5, h6),
 .content-panel h1 {


### PR DESCRIPTION
- JetBrains Mono renders ligatures by default, so sequences like `->` showed up as single glyphs in code
- Set `font-variant-ligatures: none` on `code`, `pre`, `kbd` and `samp` globally
- The quick-start terminal renders commands in plain `div`s, so it gets the same declaration on `.term`
