### PR TITLE
fix: community meeting link

### DIFF
--- a/src/content/docs/CommunityMeeting.mdx
+++ b/src/content/docs/CommunityMeeting.mdx
@@ -23,7 +23,7 @@ Using RoboStack, or just curious about it, is reason enough to join.
 Add the recurring event to your calendar, the Google Meet link is attached to it:
 
 <LinkButton
-  href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MDU1bHFrbzdlN3EzdHBjbWtxZ2poMTF1aHNfMjAyNjA4MjBUMTQwMDAwWiBydWJlbkBwcmVmaXguZGV2&tmsrc=ruben%40prefix.dev&scp=ALL"
+  href="https://calendar.google.com/calendar/u/0?cid=Y18zN2ExNzBlZWNhMjJhYTk4MzNhODJkMDQ3ZGJiYTBjYjcyMzJlZTExN2QzMzE5NjRkZmY4ODU1MGJiZWRkYTkyQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
   icon="external"
 >
   Add the meeting to your calendar


### PR DESCRIPTION
I only tested it on the account of the owner of the link. Now it's a public calender that any one can add.