### PR TITLE
Add ros2 package names to the Rolling page

### DIFF
--- a/scripts/compare_pkg_completeness.py
+++ b/scripts/compare_pkg_completeness.py
@@ -355,24 +355,21 @@ def build(distro: str, channel: str) -> dict[str, Any]:
             ]
         )
 
-    # Exact channel artifacts without a primary rosdistro row. This includes
-    # Rolling's legacy ros-rolling-* compatibility packages and genuinely extra recipes.
-    # They have no index version or source link, but remain installable. Reuse a
-    # description when their suffix matches a package in the distribution cache.
-    prefixes = ("ros2-", "ros-rolling-") if distro == "rolling" else (f"ros-{distro}-",)
+    # Packages on the channel that rosdistro has never released: no description,
+    # index version or source repository, but installable all the same. Rolling's
+    # ros-rolling-* names are skipped here: they are empty shims pinning the
+    # ros2-* package of the same version, so a row of their own would duplicate
+    # every package on the page.
+    prefix = f"{package_prefix}-"
     released = {f"{package_prefix}-{name.replace('_', '-')}" for name in index}
     for conda_name in sorted(set(builds) - released):
-        prefix = next((prefix for prefix in prefixes if conda_name.startswith(prefix)), None)
-        if prefix is None:
+        if not conda_name.startswith(prefix):
             continue
-        suffix = conda_name.removeprefix(prefix)
-        row_name = suffix if prefix != "ros-rolling-" else f"rolling-{suffix}"
-        description = metadata.get(suffix.replace("-", "_"), "")
         packages.append(
             [
-                row_name,
+                conda_name.removeprefix(prefix),
                 conda_name,
-                description,
+                "",
                 "",
                 newest_build.get(conda_name, 0) // 1000,
                 -1,

--- a/scripts/compare_pkg_completeness.py
+++ b/scripts/compare_pkg_completeness.py
@@ -356,7 +356,7 @@ def build(distro: str, channel: str) -> dict[str, Any]:
         )
 
     # Exact channel artifacts without a primary rosdistro row. This includes
-    # Rolling's ros-rolling-* compatibility aliases and genuinely extra recipes.
+    # Rolling's legacy ros-rolling-* compatibility packages and genuinely extra recipes.
     # They have no index version or source link, but remain installable. Reuse a
     # description when their suffix matches a package in the distribution cache.
     prefixes = ("ros2-", "ros-rolling-") if distro == "rolling" else (f"ros-{distro}-",)

--- a/scripts/compare_pkg_completeness.py
+++ b/scripts/compare_pkg_completeness.py
@@ -278,7 +278,7 @@ def collect_builds(
     for bit, platform in enumerate(PLATFORMS):
         for artifact in repos[platform]:
             name = artifact["name"]
-            if not name.startswith("ros-") or name in MUTEX_NAMES:
+            if not (name.startswith("ros-") or name.startswith("ros2-")) or name in MUTEX_NAMES:
                 continue
 
             newest_build[name] = max(
@@ -332,8 +332,9 @@ def build(distro: str, channel: str) -> dict[str, Any]:
         return [[per_mutex[v].mask, per_mutex[v].version] if v in per_mutex else 0 for v in mutexes]
 
     packages: list[list[Any]] = []
+    package_prefix = "ros2" if distro == "rolling" else f"ros-{distro}"
     for name in sorted(index):
-        conda_name = f"ros-{distro}-{name.replace('_', '-')}"
+        conda_name = f"{package_prefix}-{name.replace('_', '-')}"
         per_mutex = builds.get(conda_name, {})
         entry = index[name]
 
@@ -343,7 +344,8 @@ def build(distro: str, channel: str) -> dict[str, Any]:
 
         packages.append(
             [
-                name.replace("_", "-"),  # conda spelling, `ros-<distro>-` stripped
+                name.replace("_", "-"),  # conda spelling, distro prefix stripped
+                conda_name,
                 metadata.get(name, ""),
                 entry.version,  # as released into the ROS index
                 newest_build.get(conda_name, 0) // 1000,  # newest build, seconds
@@ -353,17 +355,24 @@ def build(distro: str, channel: str) -> dict[str, Any]:
             ]
         )
 
-    # Packages on the channel that rosdistro has never released: no description,
-    # index version or source repository, but installable all the same.
-    prefix = f"ros-{distro}-"
-    released = {f"ros-{distro}-{name.replace('_', '-')}" for name in index}
+    # Exact channel artifacts without a primary rosdistro row. This includes
+    # Rolling's ros-rolling-* compatibility aliases and genuinely extra recipes.
+    # They have no index version or source link, but remain installable. Reuse a
+    # description when their suffix matches a package in the distribution cache.
+    prefixes = ("ros2-", "ros-rolling-") if distro == "rolling" else (f"ros-{distro}-",)
+    released = {f"{package_prefix}-{name.replace('_', '-')}" for name in index}
     for conda_name in sorted(set(builds) - released):
-        if not conda_name.startswith(prefix):
+        prefix = next((prefix for prefix in prefixes if conda_name.startswith(prefix)), None)
+        if prefix is None:
             continue
+        suffix = conda_name.removeprefix(prefix)
+        row_name = suffix if prefix != "ros-rolling-" else f"rolling-{suffix}"
+        description = metadata.get(suffix.replace("-", "_"), "")
         packages.append(
             [
-                conda_name.removeprefix(prefix),
-                "",
+                row_name,
+                conda_name,
+                description,
                 "",
                 newest_build.get(conda_name, 0) // 1000,
                 -1,
@@ -379,7 +388,16 @@ def build(distro: str, channel: str) -> dict[str, Any]:
         "platforms": PLATFORMS,
         "mutexPackage": mutex_package,
         "mutexes": mutexes,
-        "fields": ["name", "desc", "indexVersion", "updated", "repo", "indexed", "builds"],
+        "fields": [
+            "name",
+            "condaName",
+            "desc",
+            "indexVersion",
+            "updated",
+            "repo",
+            "indexed",
+            "builds",
+        ],
         "repos": repo_urls,
         "packages": packages,
     }
@@ -414,8 +432,8 @@ def refresh(distro: str, channel: str) -> None:
 
     total = len(document["packages"])
     newest = document["mutexes"][0] if document["mutexes"] else None
-    on_newest = sum(1 for p in document["packages"] if p[6] and p[6][0])
-    ever = sum(1 for p in document["packages"] if any(p[6]))
+    on_newest = sum(1 for p in document["packages"] if p[7] and p[7][0])
+    ever = sum(1 for p in document["packages"] if any(p[7]))
     print(
         f"  -> {path}: {total} packages, {ever} built at some point, "
         f"{on_newest} on mutex {newest}, {path.stat().st_size / 1e6:.2f} MB",

--- a/src/components/package-table/PackageTable.svelte
+++ b/src/components/package-table/PackageTable.svelte
@@ -474,6 +474,9 @@
           {/if}
           {#each slice as row, i (row.name)}
             {@const conda = row.condaName}
+            <!-- Every row on a page carries the same prefix, so it is split
+                 back off the conda name for the muted/hidden treatment. -->
+            {@const prefix = conda.slice(0, conda.length - row.name.length)}
             <!-- The ROS index spells package names with underscores; conda
                  uses hyphens. -->
             {@const rosName = row.name.replace(/-/g, "_")}
@@ -490,7 +493,7 @@
                 ></span>
                 <span class="rs-name">
                   <span class="rs-pkg">
-                    {conda}
+                    <span class="rs-prefix">{prefix}</span>{row.name}
                   </span>
                   <!--
                     On this mutex: the version built for it, plus an orange

--- a/src/components/package-table/PackageTable.svelte
+++ b/src/components/package-table/PackageTable.svelte
@@ -473,7 +473,7 @@
             </tr>
           {/if}
           {#each slice as row, i (row.name)}
-            {@const conda = "ros-" + distro + "-" + row.name}
+            {@const conda = row.condaName}
             <!-- The ROS index spells package names with underscores; conda
                  uses hyphens. -->
             {@const rosName = row.name.replace(/-/g, "_")}
@@ -490,7 +490,7 @@
                 ></span>
                 <span class="rs-name">
                   <span class="rs-pkg">
-                    <span class="rs-prefix">ros-{distro}-</span>{row.name}
+                    {conda}
                   </span>
                   <!--
                     On this mutex: the version built for it, plus an orange

--- a/src/components/package-table/data.ts
+++ b/src/components/package-table/data.ts
@@ -32,18 +32,18 @@ export interface Upgrade {
 }
 
 export interface Row {
-  /** Prefix-free key used to identify the row. It normally uses the ROS package
-   * name with Conda's hyphen spelling; legacy compatibility names are disambiguated. */
+  /** The ROS package name in conda's hyphen spelling, with the distro's
+   * package prefix stripped. */
   name: string;
-  /** Complete package name exactly as published in the Conda channel, such as
-   * `ros2-desktop` or its legacy `ros-rolling-desktop` compatibility name. */
+  /** The name the package is published under on the channel, prefix and all:
+   * `ros2-desktop` on rolling, `ros-jazzy-desktop` everywhere else. */
   condaName: string;
   desc: string;
   indexVersion: string;
   updated: number;
   repo: string;
-  /** Whether this is the primary Conda row for a package released into the
-   * ROS index. False for channel-only and legacy compatibility packages. */
+  /** Released into the ROS index. False for packages that only exist on the
+   * channel: no description, index version or source repository. */
   indexed: boolean;
   builds: BuildSlot[];
   haystack: string;
@@ -96,9 +96,9 @@ export function unpackRows(doc: Doc): Row[] {
   doc.fields.forEach((field, i) => (at[field] = i));
   return doc.packages.map((pkg) => {
     const name = pkg[at.name] as string;
-    // Older snapshots predate condaName and used ros-<distro>-<name>.
-    // Preserve that exact historical spelling instead of applying today's
-    // Rolling ros2-* convention to old data.
+    // The committed foxy and galactic snapshots predate condaName. They are
+    // ROS 1-era ros-<distro>-<name> data, so reconstruct that spelling rather
+    // than applying today's rolling ros2-* convention to them.
     const condaName =
       ((pkg[at.condaName] ?? "") as string) || `ros-${doc.distro}-${name}`;
     const desc = (pkg[at.desc] ?? "") as string;

--- a/src/components/package-table/data.ts
+++ b/src/components/package-table/data.ts
@@ -33,17 +33,17 @@ export interface Upgrade {
 
 export interface Row {
   /** Prefix-free key used to identify the row. It normally uses the ROS package
-   * name with Conda's hyphen spelling; compatibility aliases are disambiguated. */
+   * name with Conda's hyphen spelling; legacy compatibility names are disambiguated. */
   name: string;
   /** Complete package name exactly as published in the Conda channel, such as
-   * `ros2-desktop` or its `ros-rolling-desktop` compatibility alias. */
+   * `ros2-desktop` or its legacy `ros-rolling-desktop` compatibility name. */
   condaName: string;
   desc: string;
   indexVersion: string;
   updated: number;
   repo: string;
   /** Whether this is the primary Conda row for a package released into the
-   * ROS index. False for channel-only packages and compatibility aliases. */
+   * ROS index. False for channel-only and legacy compatibility packages. */
   indexed: boolean;
   builds: BuildSlot[];
   haystack: string;

--- a/src/components/package-table/data.ts
+++ b/src/components/package-table/data.ts
@@ -32,13 +32,18 @@ export interface Upgrade {
 }
 
 export interface Row {
+  /** Prefix-free key used to identify the row. It normally uses the ROS package
+   * name with Conda's hyphen spelling; compatibility aliases are disambiguated. */
   name: string;
+  /** Complete package name exactly as published in the Conda channel, such as
+   * `ros2-desktop` or its `ros-rolling-desktop` compatibility alias. */
+  condaName: string;
   desc: string;
   indexVersion: string;
   updated: number;
   repo: string;
-  /** Released into the ROS index. False for packages that only exist on the
-   * channel: no description, index version or source repository. */
+  /** Whether this is the primary Conda row for a package released into the
+   * ROS index. False for channel-only packages and compatibility aliases. */
   indexed: boolean;
   builds: BuildSlot[];
   haystack: string;
@@ -91,17 +96,23 @@ export function unpackRows(doc: Doc): Row[] {
   doc.fields.forEach((field, i) => (at[field] = i));
   return doc.packages.map((pkg) => {
     const name = pkg[at.name] as string;
+    // Older snapshots predate condaName and used ros-<distro>-<name>.
+    // Preserve that exact historical spelling instead of applying today's
+    // Rolling ros2-* convention to old data.
+    const condaName =
+      ((pkg[at.condaName] ?? "") as string) || `ros-${doc.distro}-${name}`;
     const desc = (pkg[at.desc] ?? "") as string;
     const repo = pkg[at.repo] as number;
     return {
       name,
+      condaName,
       desc,
       indexVersion: (pkg[at.indexVersion] ?? "") as string,
       updated: (pkg[at.updated] ?? 0) as number,
       repo: repo >= 0 ? (doc.repos[repo] ?? "") : "",
       indexed: at.indexed === undefined || Boolean(pkg[at.indexed]),
       builds: pkg[at.builds] as BuildSlot[], // aligned with doc.mutexes
-      haystack: (name + " " + desc).toLowerCase(),
+      haystack: (name + " " + condaName + " " + desc).toLowerCase(),
     };
   });
 }

--- a/src/content/docs/GettingStarted.mdx
+++ b/src/content/docs/GettingStarted.mdx
@@ -245,7 +245,8 @@ ros-lyrical-desktop = "*"
 channels = ["https://prefix.dev/robostack-rolling"]
 
 [feature.rolling.dependencies]
-ros-rolling-desktop = "*"
+ros2-desktop = "*"
+# The supported compatibility name is also available as ros-rolling-desktop.
 ```
 
 ```bash

--- a/src/content/docs/GettingStarted.mdx
+++ b/src/content/docs/GettingStarted.mdx
@@ -246,7 +246,7 @@ channels = ["https://prefix.dev/robostack-rolling"]
 
 [feature.rolling.dependencies]
 ros2-desktop = "*"
-# The supported compatibility name is also available as ros-rolling-desktop.
+# The legacy compatibility name is also available as ros-rolling-desktop.
 ```
 
 ```bash

--- a/src/content/docs/GettingStarted.mdx
+++ b/src/content/docs/GettingStarted.mdx
@@ -246,7 +246,6 @@ channels = ["https://prefix.dev/robostack-rolling"]
 
 [feature.rolling.dependencies]
 ros2-desktop = "*"
-# The legacy compatibility name is also available as ros-rolling-desktop.
 ```
 
 ```bash

--- a/src/content/docs/conda.mdx
+++ b/src/content/docs/conda.mdx
@@ -91,7 +91,7 @@ There are different channels depending on the version of ROS that you wish to in
     ```bash
     # Create a ROS 2 Rolling desktop environment
     conda create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
-    # The supported compatibility name is also available:
+    # The legacy compatibility name is also available:
     # conda create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     conda activate ros_env

--- a/src/content/docs/conda.mdx
+++ b/src/content/docs/conda.mdx
@@ -89,8 +89,10 @@ There are different channels depending on the version of ROS that you wish to in
   </TabItem>
   <TabItem label="ROS 2 Rolling">
     ```bash
-    # Create a ros-rolling desktop environment
-    conda create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
+    # Create a ROS 2 Rolling desktop environment
+    conda create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
+    # The supported compatibility name is also available:
+    # conda create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     conda activate ros_env
     # Add the robostack channel to the environment

--- a/src/content/docs/conda.mdx
+++ b/src/content/docs/conda.mdx
@@ -91,8 +91,6 @@ There are different channels depending on the version of ROS that you wish to in
     ```bash
     # Create a ROS 2 Rolling desktop environment
     conda create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
-    # The legacy compatibility name is also available:
-    # conda create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     conda activate ros_env
     # Add the robostack channel to the environment

--- a/src/content/docs/micromamba.mdx
+++ b/src/content/docs/micromamba.mdx
@@ -86,8 +86,10 @@ There are different channels depending on the version of ROS that you wish to in
   </TabItem>
   <TabItem label="ROS 2 Rolling">
     ```bash
-    # Create a ros-rolling desktop environment
-    micromamba create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
+    # Create a ROS 2 Rolling desktop environment
+    micromamba create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
+    # The supported compatibility name is also available:
+    # micromamba create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     micromamba activate ros_env
     # Add the robostack channel to the environment

--- a/src/content/docs/micromamba.mdx
+++ b/src/content/docs/micromamba.mdx
@@ -88,8 +88,6 @@ There are different channels depending on the version of ROS that you wish to in
     ```bash
     # Create a ROS 2 Rolling desktop environment
     micromamba create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
-    # The legacy compatibility name is also available:
-    # micromamba create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     micromamba activate ros_env
     # Add the robostack channel to the environment

--- a/src/content/docs/micromamba.mdx
+++ b/src/content/docs/micromamba.mdx
@@ -88,7 +88,7 @@ There are different channels depending on the version of ROS that you wish to in
     ```bash
     # Create a ROS 2 Rolling desktop environment
     micromamba create -n ros_env -c conda-forge -c robostack-rolling ros2-desktop
-    # The supported compatibility name is also available:
+    # The legacy compatibility name is also available:
     # micromamba create -n ros_env -c conda-forge -c robostack-rolling ros-rolling-desktop
     # Activate the environment
     micromamba activate ros_env

--- a/src/data/distros.ts
+++ b/src/data/distros.ts
@@ -98,6 +98,10 @@ export function browseUrl(distro: Distro): string {
 export function title(distro: Distro): string {
   return distro.name.charAt(0).toUpperCase() + distro.name.slice(1);
 }
+/** The conda package prefix used for the distro's primary packages. */
+export function packagePrefix(distro: Distro): string {
+  return distro.name === "rolling" ? "ros2" : `ros-${distro.name}`;
+}
 
 /** The release and support summary shown under the title. */
 export function supportLine(distro: Distro): string {

--- a/src/pages/[distro].astro
+++ b/src/pages/[distro].astro
@@ -28,7 +28,7 @@ const install = [
   `pixi workspace channel add ${distro.base}/${distro.channel}`,
   `pixi add ${packagePrefix(distro)}-<package>`,
   ...(distro.name === "rolling"
-    ? ["# Compatibility alias: pixi add ros-rolling-<package>"]
+    ? ["# Legacy compatibility name: pixi add ros-rolling-<package>"]
     : []),
 ].join("\n");
 ---

--- a/src/pages/[distro].astro
+++ b/src/pages/[distro].astro
@@ -27,9 +27,6 @@ const browse = browseUrl(distro);
 const install = [
   `pixi workspace channel add ${distro.base}/${distro.channel}`,
   `pixi add ${packagePrefix(distro)}-<package>`,
-  ...(distro.name === "rolling"
-    ? ["# Legacy compatibility name: pixi add ros-rolling-<package>"]
-    : []),
 ].join("\n");
 ---
 

--- a/src/pages/[distro].astro
+++ b/src/pages/[distro].astro
@@ -3,7 +3,13 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { Aside, Code } from "@astrojs/starlight/components";
 import PackageTable from "../components/package-table/PackageTable.astro";
 import type { Distro } from "../data/distros";
-import { browseUrl, DISTROS, monthYear, title } from "../data/distros";
+import {
+  browseUrl,
+  DISTROS,
+  monthYear,
+  packagePrefix,
+  title,
+} from "../data/distros";
 
 export function getStaticPaths() {
   return DISTROS.map((distro) => ({
@@ -20,7 +26,10 @@ const { distro } = Astro.props;
 const browse = browseUrl(distro);
 const install = [
   `pixi workspace channel add ${distro.base}/${distro.channel}`,
-  `pixi add ros-${distro.name}-<package>`,
+  `pixi add ${packagePrefix(distro)}-<package>`,
+  ...(distro.name === "rolling"
+    ? ["# Compatibility alias: pixi add ros-rolling-<package>"]
+    : []),
 ].join("\n");
 ---
 


### PR DESCRIPTION
## Summary

- include canonical ros2-* artifacts on the Rolling package page while retaining legacy ros-rolling-* compatibility packages
- store and display exact Conda artifact names without changing Humble, Jazzy, Kilted, or Lyrical naming
- recommend ros2-* in Rolling installation examples

## Validation

- pixi run lint
- pixi run build-docs
- pixi run python scripts/compare_pkg_completeness.py rolling https://prefix.dev/robostack-rolling
- verified generated non-Rolling pages contain no ros2-* package instructions
- git diff --check